### PR TITLE
Establish baseline measurement and document process

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,11 @@ jmeter
 1. Go to the User Defined Variables under the top-level "Solr test plan" and make sure the variables match the environment you want to work against (see [User Defined Variables by Environment below](#user-defined-variables-by-environment))
 1. In order to run the current test plan, click the green arrow button.
 
-## Running from loadtest.lib.princeton.edu
+## Running from loadtest1.lib.princeton.edu
 * Ensure the User Defined Variables in the Solr test plan are correct and saved for the environment (see [User Defined Variables by Environment below](#user-defined-variables-by-environment))
-* Copy the test file onto the remote host
-```bash
-scp solr_test_plan.jmx deploy@loadtest1.lib.princeton.edu:~/
-```
-* Copy the keywords file onto the remote host
-```bash
-scp keywords.csv deploy@loadtest1.lib.princeton.edu:~/
-```
+* This project is checked out at `/home/deploy/solr_load_testing`
+* You can make changes locally, commit and push them to a branch, then check that branch out on the server
+
 * SSH onto the box
 ```bash
 ssh deploy@loadtest1.lib.princeton.edu
@@ -30,7 +25,7 @@ ssh deploy@loadtest1.lib.princeton.edu
 ```bash
 jmeter -n -t solr_test_plan.jmx -e -l test_report-$(date +"%Y-%m-%d:%H:%M:%S").jtl -o ./test_results-$(date +"%Y-%m-%d:%H:%M:%S")/
 ```
-* Look at the results on the web at loadtest.lib.princeton.edu/solr_tests/
+* Look at the results on the web at loadtest.lib.princeton.edu/solr_tests/ (VPN required)
 ## User Defined Variables by Environment
 ### Development
 ```
@@ -69,3 +64,6 @@ lrwxr-xr-x  1 kadelm  admin  20 May 30 09:28 /opt/homebrew/opt/jmeter -> ../Cell
   1. For "Output directory" create an empty directory
   1. Click "Generate report"
 1. Open the generated index.html file using your browser
+
+### Record the trial in the spreadsheet
+Record what experiment you did, and a link to the report that was generated, in [this spreadsheet](https://docs.google.com/spreadsheets/d/1zvbCHYgnx0KFNtwVmNV6-yHDJN84kIRKbO5YvywiYFk/edit?usp=sharing).

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ ssh deploy@loadtest1.lib.princeton.edu
 ```
 * Run the jmeter test from loadtest1.lib.princeton.edu
 ```bash
-jmeter -n -t solr_test_plan.jmx -e -l test_report-$(date +"%Y-%m-%d:%H:%M:%S").jtl -o ./test_results-$(date +"%Y-%m-%d:%H:%M:%S")/
+jmeter -n -t solr_test_plan.jmx -e -l test_report-$(date +"%Y-%m-%d:%H:%M:%S").jtl -o /home/deploy/solr_tests/test_results-$(date +"%Y-%m-%d:%H:%M:%S")/
 ```
-* Look at the results on the web at loadtest.lib.princeton.edu/solr_tests/ (VPN required)
+* Look at the results on the web at [loadtest.lib.princeton.edu/solr_tests/](https://loadtest.lib.princeton.edu/solr_tests/) (VPN required)
 ## User Defined Variables by Environment
 ### Development
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ssh deploy@loadtest1.lib.princeton.edu
 ```
 * Run the jmeter test from loadtest1.lib.princeton.edu
 ```bash
-jmeter -n -t solr_test_plan.jmx -e -l test_report-$(date +"%Y-%m-%d:%H:%M:%S").jtl -o /home/deploy/solr_tests/test_results-$(date +"%Y-%m-%d:%H:%M:%S")/
+jmeter -n -t /home/deploy/solr_load_testing/solr_test_plan.jmx -e -l /home/deploy/solr_load_testing/test_report-$(date +"%Y-%m-%d:%H:%M:%S").jtl -o /home/deploy/solr_tests/test_results-$(date +"%Y-%m-%d:%H:%M:%S")/
 ```
 * Look at the results on the web at [loadtest.lib.princeton.edu/solr_tests/](https://loadtest.lib.princeton.edu/solr_tests/) (VPN required)
 ## User Defined Variables by Environment

--- a/solr_test_plan.jmx
+++ b/solr_test_plan.jmx
@@ -37,8 +37,6 @@
           </elementProp>
         </collectionProp>
       </elementProp>
-      <boolProp name="TestPlan.functional_mode">false</boolProp>
-      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
     </TestPlan>
     <hashTree>
       <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config">
@@ -54,12 +52,12 @@
       </CSVDataSet>
       <hashTree/>
       <SetupThreadGroup guiclass="SetupThreadGroupGui" testclass="SetupThreadGroup" testname="setUp Thread Group">
-        <intProp name="ThreadGroup.num_threads">50</intProp>
+        <intProp name="ThreadGroup.num_threads">200</intProp>
         <intProp name="ThreadGroup.ramp_time">1</intProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">false</boolProp>
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
-          <stringProp name="LoopController.loops">500</stringProp>
+          <stringProp name="LoopController.loops">1000</stringProp>
           <boolProp name="LoopController.continue_forever">false</boolProp>
         </elementProp>
       </SetupThreadGroup>
@@ -452,7 +450,7 @@
           </elementProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="JSON Assertion - status">
+          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="JSON Assertion - status" enabled="true">
             <stringProp name="JSON_PATH">$.responseHeader.status</stringProp>
             <stringProp name="EXPECTED_VALUE">0</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
@@ -471,7 +469,7 @@
             <boolProp name="ISREGEX">true</boolProp>
           </JSONPathAssertion>
           <hashTree/>
-          <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree">
+          <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
             <boolProp name="ResultCollector.error_logging">false</boolProp>
             <objProp>
               <name>saveConfig</name>
@@ -509,7 +507,7 @@
           </ResultCollector>
           <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Multiple Keyword Request" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Multiple Keyword Request">
           <stringProp name="TestPlan.comments">Iterate through keywords - imitates search from homepage with single word query</stringProp>
           <stringProp name="HTTPSampler.domain">${host}</stringProp>
           <stringProp name="HTTPSampler.port">${port}</stringProp>
@@ -897,7 +895,7 @@
           </elementProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="JSON Assertion - status">
+          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="JSON Assertion - status" enabled="true">
             <stringProp name="JSON_PATH">$.responseHeader.status</stringProp>
             <stringProp name="EXPECTED_VALUE">0</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>

--- a/solr_test_plan.jmx
+++ b/solr_test_plan.jmx
@@ -32,7 +32,7 @@
           </elementProp>
           <elementProp name="keyword_file_full_path" elementType="Argument">
             <stringProp name="Argument.name">keyword_file_full_path</stringProp>
-            <stringProp name="Argument.value">/home/deploy/keywords.csv</stringProp>
+            <stringProp name="Argument.value">/home/deploy/solr_load_testing/keywords.csv</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>
@@ -62,7 +62,7 @@
         </elementProp>
       </SetupThreadGroup>
       <hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Single Keyword Request">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Single Keyword Request" enabled="true">
           <stringProp name="TestPlan.comments">Keyword search from homepage with single word query</stringProp>
           <stringProp name="HTTPSampler.domain">${host}</stringProp>
           <stringProp name="HTTPSampler.port">${port}</stringProp>
@@ -507,7 +507,7 @@
           </ResultCollector>
           <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Multiple Keyword Request">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Multiple Keyword Request" enabled="true">
           <stringProp name="TestPlan.comments">Iterate through keywords - imitates search from homepage with single word query</stringProp>
           <stringProp name="HTTPSampler.domain">${host}</stringProp>
           <stringProp name="HTTPSampler.port">${port}</stringProp>


### PR DESCRIPTION
* We added a google spreadsheet to track experiments, and added a link in the README
* We changed our process to run the tests on the server. Instead of using scp to copy the file, we checked this repo out on the server, and we can make local changes to the test plan, commit to a branch, then check that branch out on the server
* We wanted to establish a baseline measurement, and then adjust the number of users and the number of loops to see what that did to the report
* ~However, we hit an error:~
> Error generating the report: org.apache.jmeter.report.dashboard.GenerationException: Error while processing samples: Consumer failed with message :Consumer failed with message :Consumer failed with message :Consumer failed with message :Consumer failed with message :Could not read sample <317959>
... end of run

Resolved the error above by using absolute paths. 